### PR TITLE
add/tweak doom highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ use 'NTBBloodbath/doom-one.nvim'
 - `doom_one_italic_comments` - Enable italic comments, `v:false` by default.
 - `doom_one_transparent_background` - Enable transparent background, `v:false` by default.
 - `doom_one_cursor_coloring` - Enable cursor coloring (blue), `v:false` by default.
+- `doom_one_telescope_highlights` - Enable telescope highlighting, `v:true` by default
 
 > **NOTE:** All those options are global Vim variables and uses `v:true` / `v:false` instead of `1` / `0`.
 > So if you're using Lua you will need to use `true` / `false`.

--- a/lua/doom-one-light/init.lua
+++ b/lua/doom-one-light/init.lua
@@ -29,6 +29,9 @@ end
 if vim.g.doom_one_italic_comments == nil then
     vim.g.doom_one_italic_comments = false
 end
+if vim.g.doom_one_telescope_highlights == nil then
+    vim.g.doom_one_telescope_highlights = true
+end
 
 local transparent_bg = vim.g.doom_one_transparent_background
 
@@ -230,6 +233,7 @@ apply_highlight(buffers_ui)
 
 local search_high_ui = {
 	Search = { fg = fg, bg = dark_blue, gui = 'bold' },
+	Substitute = {fg = red, gui = 'strikethrough,bold'},
 	IncSearch = { fg = fg, bg = dark_blue, gui = 'bold' },
 	IncSearchCursor = { gui = 'reverse' },
 
@@ -428,21 +432,23 @@ high_link('GitSignsChangeDelete', 'DiffModifiedGutter')
 
 -- Telescope {{{
 
-local telescope = {
-	TelescopeSelection = { fg = yellow, gui = 'bold' },
-	TelescopeSelectionCaret = { fg = blue },
-	TelescopeMultiSelection = { fg = grey },
-	TelescopeNormal = { fg = fg },
-	TelescopeMatching = { fg = green, gui = 'bold' },
-	TelescopePromptPrefix = { fg = blue },
-	TelescopeBorder = { fg = blue },
-	TelescopePromptBorder = { fg = blue },
-	TelescopeResultsBorder = { fg = blue },
-	TelescopePreviewBorder = { fg = blue },
-}
+if vim.g.doom_one_telescope_highlights then
+	local telescope = {
+	    TelescopeSelection = { fg = yellow, gui = 'bold' },
+	    TelescopeSelectionCaret = { fg = blue },
+	    TelescopeMultiSelection = { fg = grey },
+	    TelescopeNormal = { fg = fg },
+	    TelescopeMatching = { fg = green, gui = 'bold' },
+	    TelescopePromptPrefix = { fg = blue },
+	    TelescopeBorder = { fg = blue },
+	    TelescopePromptBorder = { fg = blue },
+	    TelescopeResultsBorder = { fg = blue },
+	    TelescopePreviewBorder = { fg = blue },
+	}
 
-apply_highlight(telescope)
-high_link('TelescopePrompt', 'TelescopeNormal')
+	apply_highlight(telescope)
+	high_link('TelescopePrompt', 'TelescopeNormal')
+end
 
 -- }}}
 
@@ -632,7 +638,7 @@ if vim.g.doom_one_enable_treesitter then
 	high_link('TSDanger', 'Error')
 	high_link('TSType', 'Type')
 	high_link('TSTypeBuiltin', 'TypeBuiltin')
-	high_link('TSVariable', 'Variable')
+	high_link('TSVariable', 'None')
 	high_link('TSVariableBuiltin', 'VariableBuiltin')
 end
 

--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -188,8 +188,8 @@ local general_ui = {
 	PmenuThumb = { bg = fg },
 }
 
-if vim.fn.exists('&pumblend') == 1 then
-	vim.cmd('set pumblend=20')
+if vim.opt.pumblend == 1 then
+	vim.opt.pumblend = 20
 end
 
 apply_highlight(general_ui)

--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -181,7 +181,7 @@ local general_ui = {
 	StatusLinePart = { fg = base6, bg = bg_popup, gui = 'bold' },
 	StatusLinePartNC = { fg = base6, bg = bg_popup, gui = 'bold' },
 
-	Pmenu = { fg = fg, bg = bg_popup },
+	Pmenu = { fg = fg, bg = bg_highlight },
 	PmenuSel = { fg = base0, bg = blue },
 	PmenuSelBold = { fg = base0, bg = blue, gui = 'bold' },
 	PmenuSbar = { bg = bg_alt },

--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -631,7 +631,7 @@ if vim.g.doom_one_enable_treesitter then
 	high_link('TSDanger', 'Error')
 	high_link('TSType', 'Type')
 	high_link('TSTypeBuiltin', 'TypeBuiltin')
-	high_link('TSVariable', 'Variable')
+	high_link('TSVariable', 'None')
 	high_link('TSVariableBuiltin', 'VariableBuiltin')
 end
 

--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -347,7 +347,7 @@ local main_syntax = {
 	Argument = { fg = light_magenta },
 	Attribute = { fg = light_magenta },
 	Identifier = { fg = light_magenta },
-	Property = { fg = violet },
+	Property = { fg = magenta },
 	Function = { fg = magenta },
 	FunctionBuiltin = { fg = light_magenta, gui = 'bold' },
 	KeywordFunction = { fg = blue },

--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -29,6 +29,9 @@ end
 if vim.g.doom_one_italic_comments == nil then
     vim.g.doom_one_italic_comments = false
 end
+if vim.g.doom_one_telescope_highlights == nil then
+    vim.g.doom_one_telescope_highlights = true
+end
 
 local transparent_bg = vim.g.doom_one_transparent_background
 
@@ -430,21 +433,23 @@ high_link('GitSignsChangeDelete', 'DiffModifiedGutter')
 
 -- Telescope {{{
 
-local telescope = {
-	TelescopeSelection = { fg = yellow, gui = 'bold' },
-	TelescopeSelectionCaret = { fg = blue },
-	TelescopeMultiSelection = { fg = grey },
-	TelescopeNormal = { fg = fg },
-	TelescopeMatching = { fg = green, gui = 'bold' },
-	TelescopePromptPrefix = { fg = blue },
-	TelescopeBorder = { fg = blue },
-	TelescopePromptBorder = { fg = blue },
-	TelescopeResultsBorder = { fg = blue },
-	TelescopePreviewBorder = { fg = blue },
-}
+if vim.g.doom_one_telescope_highlights then
+	local telescope = {
+	    TelescopeSelection = { fg = yellow, gui = 'bold' },
+	    TelescopeSelectionCaret = { fg = blue },
+	    TelescopeMultiSelection = { fg = grey },
+	    TelescopeNormal = { fg = fg },
+	    TelescopeMatching = { fg = green, gui = 'bold' },
+	    TelescopePromptPrefix = { fg = blue },
+	    TelescopeBorder = { fg = blue },
+	    TelescopePromptBorder = { fg = blue },
+	    TelescopeResultsBorder = { fg = blue },
+	    TelescopePreviewBorder = { fg = blue },
+	}
 
-apply_highlight(telescope)
-high_link('TelescopePrompt', 'TelescopeNormal')
+	apply_highlight(telescope)
+	high_link('TelescopePrompt', 'TelescopeNormal')
+end
 
 -- }}}
 

--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -231,6 +231,7 @@ apply_highlight(buffers_ui)
 
 local search_high_ui = {
 	Search = { fg = fg, bg = dark_blue, gui = 'bold' },
+	Substitute = {fg = red, gui = 'strikethrough,bold'},
 	IncSearch = { fg = fg, bg = dark_blue, gui = 'bold' },
 	IncSearchCursor = { gui = 'reverse' },
 


### PR DESCRIPTION
So this PR adds and changes a few things, I was hesitant about opening it since I have these things in my config anyway but I though maybe other people would like them so decided to contribute the changes.

I've laid it out as a series of separate commits, so I can remove anything that is too controversial or that you would prefer not to include. Regarding the highlight changes since these are easy to override I'm happy to take things out or maybe make them optional with variables 🤷🏾 

So changes include:
1. Darkening the `Pmenu` - this change makes the completion menu dark which matches with doom better, I get that it's maybe controversial, so I can make it optional or remove it.
#### This plugin
![menu_doom](https://user-images.githubusercontent.com/22454918/122265460-ae6f9600-ced0-11eb-9a5e-0fb6a1045f91.png)
#### Doom emacs
![doom_menu](https://raw.githubusercontent.com/hlissner/doom-emacs/screenshots/company.png)
2. Add `Substitute` highlight
#### This plugin
![substitute_doom](https://user-images.githubusercontent.com/22454918/122265630-dd860780-ced0-11eb-9477-0425bcef9763.png)
#### Doom emacs
![image](https://user-images.githubusercontent.com/22454918/122265685-ebd42380-ced0-11eb-9d34-6be57ee4f6c0.png)

3. Remove `TSVariable` highlight - this one is maybe controversial, but I've noticed some new themes are all highlighting this, which I think is quite weird. Almost all `syntax` themes don't highlight variables since they are *super* common in programming, so it really seems odd to distinguish them and turn the whole file into one colour.

I could for show a screen grab from doom as well that shows that it doesn't do that, but I think this is more about how people are handling treesitter highlights. Anyway, up to you, I can remove that commit and just do it in my config.

4. Make `Telescope` highlights optional - I get not making this theme too complex with options may be an issue, but I find that I quite liked the default styling or minimal colouring of telescope (personal preference I know) and trying to remove the highlights this plugin adds is kind of laborious, so this option allows it to be switched off.

I guess that this could apply to other plugins, but tbh I think it handles other plugins quite nicely so 🤷🏾. Also didn't want this to get too long.
