### PR TITLE
feat: add markdown highlights (for lsp)

### DIFF
--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -438,6 +438,18 @@ apply_highlight(diff)
 
 -- }}}
 
+-- Markdown {{{
+local markdown = {
+      markdownCode = { bg = bg_highlight  },
+      markdownCodeBlock = { bg = bg_highlight  },
+      markdownH1 = { gui = "bold"  },
+      markdownH2 = { gui = "bold"  },
+      markdownLinkText = { gui = "underline"  },
+}
+
+apply_highlight(markdown)
+--}}}
+
 -- Plugins {{{
 
 -- barbar.nvim {{{


### PR DESCRIPTION
This PR adds  highlight rules for a few key markdown groups used by neovim's native lsp. It has its own custom markdown syntax based on the default markdown syntax file. Without these groups things like syntax based highlighting for code blocks and other types of markdown highlighting in hover windows does not show.

See [this comment](https://github.com/neovim/neovim/pull/14907#issuecomment-869160441) in a related issue in neovim for more context.

<details>

![doom-markdown](https://user-images.githubusercontent.com/22454918/123635410-8eff3400-d813-11eb-9862-568de580cf47.png)

</details>

![image](https://user-images.githubusercontent.com/22454918/123671539-502ea580-d836-11eb-95cf-39e66329e990.png)


~Still need to actually test these changes fully locally hard to find each one of these groups in a floating window, need the right symbols 🤣~ - __Done__