### PR TITLE
feat: add Startify highlighting group

### DIFF
--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -556,6 +556,19 @@ local dashboard = {
 
 -- }}}
 
+-- Startify {{{
+
+local startify = {
+	StartifyHeader = { fg = bg_popup },
+	StartifyBracket = { fg = bg_popup },
+	StartifyNumber = { fg = blue },
+	StartifyPath = { fg = violet },
+	StartifySlash = { fg = violet },
+	StartifyFile = { fg = green },
+}
+
+-- }}}
+
 -- WhichKey {{{
 
 local whichkey = {
@@ -638,6 +651,7 @@ async = vim.loop.new_async(vim.schedule_wrap(function()
 		whichkey,
 		msg_underline,
 		lspsaga,
+		startify,
 	}
 
 	-- Text levels {{{


### PR DESCRIPTION
Okay so I added the Startify highlighting group, I feel like I'm the one of the few who still use it, but I added the colors so I thought I might as well make a pull request. Not sure if I'm doing this correctly since this is my first pull request on GitHub.

I think the changes made the theme way easier on the eyes and I feel like it fits Doom well.

Let me know what you think, I provided some screenshots.

Before:
![2021-07-22-181827_932x920_scrot](https://user-images.githubusercontent.com/39461169/126674445-512ff389-bff7-4d95-af15-77fd8082dcf3.png)

After:
![2021-07-22-181751_933x919_scrot](https://user-images.githubusercontent.com/39461169/126674463-2a9d6d14-3ce7-4e9c-8db1-ffac792787f6.png)
