### PR TITLE
add visible highlights for LspReference*

### DIFF
--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -303,6 +303,7 @@ local search_high_ui = {
 
 	Highlight = { bg = bg_highlighted },
 	HighlightSubtle = { bg = bg_highlighted },
+	LspHighlight = { bg = bg_highlight, style = 'bold' },
 
 	Question = { fg = green, gui = 'bold' },
 
@@ -821,9 +822,9 @@ high_link('DiagnosticSignError', 'ErrorMsg')
 high_link('DiagnosticSignWarning', 'WarningMsg')
 high_link('DiagnosticSignInformation', 'MoreMsg')
 high_link('DiagnosticSignHint', 'Msg')
-high_link('LspReferenceText', 'Bold')
-high_link('LspReferenceRead', 'Bold')
-high_link('LspReferenceWrite', 'Bold')
+high_link('LspReferenceText', 'LspHighlight')
+high_link('LspReferenceRead', 'LspHighlight')
+high_link('LspReferenceWrite', 'LspHighlight')
 high_link('TermCursor', 'Cursor')
 high_link('healthError', 'ErrorMsg')
 high_link('healthSuccess', 'Msg')


### PR DESCRIPTION
when we have sth like this
```vim
      augroup lsp_document_highlight
        autocmd! * <buffer>
        autocmd CursorHold <buffer> lua vim.lsp.buf.document_highlight()
        autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()
      augroup END
```
the references are not visible by default, let's make them visible,
**I can make a flag for if you don't like this to be the default behavior**

---

before this change:
<img width="395" alt="before" src="https://user-images.githubusercontent.com/10992695/135750411-685a9cd3-7b46-41a9-a823-f2f70feca97a.png">

---

after this change:
<img width="394" alt="after" src="https://user-images.githubusercontent.com/10992695/135750419-479c5538-ce92-423d-b67a-ea484b81f355.png">
