### PR TITLE
(Fix) use config instead of setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Packer
 ```lua
 use({
     'NTBBloodbath/doom-one.nvim',
-    setup = function()
+    config = function()
         require('doom-one').setup({
             cursor_coloring = false,
             terminal_colors = false,


### PR DESCRIPTION
require 'doom-one' on setup function should through error. It should be config function.