### PR TITLE
new option: diagnostics_color_text

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ use({
             italic_comments = false,
             enable_treesitter = true,
             transparent_background = false,
+            diagnostics_color_text = true,
             pumblend = {
                 enable = true,
                 transparency_amount = 20,

--- a/lua/doom-one/config/init.lua
+++ b/lua/doom-one/config/init.lua
@@ -7,6 +7,7 @@ local configuration = {
     italic_comments = false,
     enable_treesitter = true,
     transparent_background = false,
+    diagnostics_color_text = true,
     pumblend = {
         enable = true,
         transparency_amount = 20,

--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -43,9 +43,10 @@ local function highlight(group, styles)
 	local fg = styles.fg and 'guifg=' .. styles.fg or 'guifg=NONE'
 	local sp = styles.sp and 'guisp=' .. styles.sp or 'guisp=NONE'
 	local gui = styles.gui and 'gui=' .. styles.gui or 'gui=NONE'
+	local guisp = styles.guisp and 'guisp=' .. styles.guisp or 'guisp=NONE'
 
 	vim.api.nvim_command(
-		'hi! ' .. group .. ' ' .. bg .. ' ' .. fg .. ' ' .. sp .. ' ' .. gui
+		'hi! ' .. group .. ' ' .. bg .. ' ' .. fg .. ' ' .. sp .. ' ' .. gui .. ' ' .. guisp
 	)
 end
 
@@ -876,11 +877,19 @@ doom_one.load_colorscheme = function()
     -- LSP {{{
 
     local msg_underline = {
-	    ErrorMsgUnderline = { fg = red, gui = 'underline' },
-	    WarningMsgUnderline = { fg = yellow, gui = 'underline' },
-	    MoreMsgUnderline = { fg = blue, gui = 'underline' },
-	    MsgUnderline = { fg = green, gui = 'underline' },
+	    ErrorMsgUnderline = { guisp = red, gui = 'underline' },
+	    WarningMsgUnderline = { guisp = yellow, gui = 'underline' },
+	    MoreMsgUnderline = { guisp = blue, gui = 'underline' },
+	    MsgUnderline = { guisp = green, gui = 'underline' },
     }
+    if configuration.diagnostics_color_text then 
+	    msg_underline = {
+		    ErrorMsgUnderline = { fg = red, gui = 'underline' },
+		    WarningMsgUnderline = { fg = yellow, gui = 'underline' },
+		    MoreMsgUnderline = { fg = blue, gui = 'underline' },
+		    MsgUnderline = { fg = green, gui = 'underline' },
+	    }
+    end
 
     apply_highlight(msg_underline)
     high_link('LspDiagnosticsFloatingError', 'ErrorMsg')


### PR DESCRIPTION
new option: diagnostics_color_text, default=true (current behavior).

If false, when there is a diagnostic active, we won't color the text but only the underline. I think it's quite handy when an entire function gets marked by diagnostics, else it's entirely red and difficult to read.