### PR TITLE
Fix vim.g.terminal_color_15

### DIFF
--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -417,7 +417,7 @@ doom_one.set_colorscheme = function()
 		vim.g.terminal_color_12 = palette.blue
 		vim.g.terminal_color_13 = palette.violet
 		vim.g.terminal_color_14 = palette.cyan
-		vim.g.terminal_color_15 = palette.white
+		vim.g.terminal_color_15 = palette.base8
 		vim.g.terminal_color_background = palette.bg_alt
 		vim.g.terminal_color_foreground = palette.fg_alt
 	end


### PR DESCRIPTION
`white` is not defined anymore in `colors.lua`, causing `terminal_color_15` to be effectively nil.

This commit ties the color 15 (also known as ANSI bright white) to the `base8` from the palette, which is either white-ish or dark-ish, depending on selected background. This behavior is consistent with Doom Emacs, as hard-coded at
https://github.com/doomemacs/themes/blob/ff26f26ea3d761375f5fc4070438fbd0f3473d33/doom-themes-base.el#L201