### PR TITLE
Add support for `diff` filetype

### DIFF
--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -268,9 +268,21 @@ doom_one.set_colorscheme = function()
 	set_hl("DiffModifiedGutterLineNr", { fg = palette.grey })
 	set_hl("DiffRemovedGutterLineNr", { fg = palette.grey })
 
+	-- Used by diff mode (see `:help diff-mode`)
 	set_hl("DiffAdd", { link = "DiffAddedGutter" })
 	set_hl("DiffChange", { link = "DiffModifiedGutter" })
 	set_hl("DiffDelete", { link = "DiffRemovedGutter" })
+
+	-- Used by diff filetype (see `$VIMRUNTIME/syntax/diff.vim`)
+	set_hl("diffAdded", { fg = palette.green, bg = palette.bg_alt })
+	set_hl("diffChanged", { fg = palette.violet })
+	set_hl("diffRemoved", { fg = palette.red, bg = palette.base3 })
+	set_hl("diffLine", { fg = palette.violet })
+	set_hl("diffIndexLine", { fg = palette.cyan })
+	set_hl("diffSubname", { fg = palette.cyan })
+	set_hl("diffFile", { fg = palette.cyan })
+	set_hl("diffOldFile", { fg = palette.blue })
+	set_hl("diffNewFile", { fg = palette.blue })
 
 	--- Markdown
 	------------


### PR DESCRIPTION
The already present highlight groups supported only the builtin diff mode. Syntax highlighting for `diff` filetype uses separate, not linked highlight groups, that were previously unset, impairing user experience when e.g. opening *.diff files, or using nvim as external editor for git CLI (as the builtin `git` filetype inherits most of its highlight groups from `diff` by default).

This commit configures required highlight groups in a way that matches the style used by Doom Emacs as close as possible (full compatibility would sadly require changes to `syntax/diff.vim` as well).

As a side effect, buffers generated by the `tpope/vim-fugitive` plugin become correctly styled as well.

Sample screenshot before this change:
![Screenshot_20240225_223737](https://github.com/NTBBloodbath/doom-one.nvim/assets/6830301/74967676-ef9f-4035-b3a0-e76d33b0cb47)
After:
![Screenshot_20240225_223820](https://github.com/NTBBloodbath/doom-one.nvim/assets/6830301/fd2dbfd4-1b06-46cd-a884-30ea1c9da208)
Stock Doom Emacs for comparison:
![Screenshot_20240225_223903](https://github.com/NTBBloodbath/doom-one.nvim/assets/6830301/1fa90193-1038-464e-974f-2cb3fed8c1e7)
