### PR TITLE
Added color to the current line number in the relative line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ return {
         vim.g.doom_one_diagnostics_text_color = false
 		-- Enable transparent background
 		vim.g.doom_one_transparent_background = false
+        -- Color current line if relative line number is true, See: vim.opt.relativenumber
+        vim.g.doom_one_relative_line_color = true
 
         -- Pumblend transparency
 		vim.g.doom_one_pumblend_enable = false

--- a/lua/doom-one/init.lua
+++ b/lua/doom-one/init.lua
@@ -20,6 +20,7 @@ local config = {
 		enable_treesitter = if_nil(vim.g.doom_one_enable_treesitter, true),
 		diagnostics_text_color = if_nil(vim.g.doom_one_diagnostics_text_color, false),
 		transparent_background = if_nil(vim.g.doom_one_transparent_background, false),
+    relative_line_color = if_nil(vim.g.doom_one_relative_line_color, false),
 		pumblend = {
 			enable = if_nil(vim.g.doom_one_pumblend_enable, false),
 			transparency_amount = if_nil(vim.g.doom_one_pumblend_transparency, 20),
@@ -412,6 +413,15 @@ doom_one.set_colorscheme = function()
 	set_hl("netrwExe", { fg = palette.green, bold = true })
 	set_hl("netrwMakefile", { fg = palette.yellow, bold = true })
 	set_hl("netrwTreeBar", { link = "Comment" })
+
+  --- Relative line color for rln
+	-------------------
+	if config.ui.relative_line_color then
+    set_hl("LineNr", { bg = config.ui.transparent_background and "NONE" or palette.bg, fg = palette.cyan })
+    set_hl("LineNrAbove", { bg = config.ui.transparent_background and "NONE" or palette.bg, fg = palette.grey })
+    set_hl("LineNrBelow", { bg = config.ui.transparent_background and "NONE" or palette.bg, fg = palette.grey })
+	end
+
 
 	--- Terminal colors
 	-------------------


### PR DESCRIPTION
Hello :wave: 

The current line number is now cyan when relative line number is set to true
and lines below and above are gray.

Explanation is hard so i provide a image: [the image](https://github.com/user-attachments/assets/cda72742-3e3c-4b9d-ab5b-c43f4da48a1c)

If there is anything that need change or should be done differently, please tell.